### PR TITLE
Updates for use with Gazebo 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Boost ${MIN_BOOST_VERSION} REQUIRED system filesystem regex)
 
 find_package(Protobuf REQUIRED)
 
-include_directories(${GAZEBO_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,3 @@ Instead of a README.md the project has a [google doc](https://docs.google.com/do
   > `gzclient`
 
   With this most basic example you can send movement messages to the robot along the `/Pioneer3AT/cmd_vel` topic.
-
-
--- @ogallagher

--- a/README.md
+++ b/README.md
@@ -1,63 +1,49 @@
 # ros-pioneer3at
-Programs that show how to drive a Pioneer3-AT robot with ros (I used it for Gazebo).
-
-## This fork
-I donwloaded this example to learn how to use ROS (system for robot communication) and Gazebo (robot simulator) in tandem. This project contains more content than what I used, but at least for my case I noticed 2 shortcomings: there's no README in the original, and it doesn't work with the latest version of Gazebo, which in my case is version 9. To the former I've contributed by starting this file, and for the latter I changed a couple of source files a smidge. 
+Programs that show how to drive a Pioneer3-AT robot with ros.
 
 ## README
-Instead of a README.md the project has a [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit), which I'll try to paste below.
+This README is adapted from this [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit), which has some better formatting and diagrams if the instructions here are confusing.
 
-### Introduction
+## Introduction
 > This is a quick-start guide to using a Pioneer3AT Mobile Robot with ROS. It should allow you to drive a robot via a GUI application or a PS3 controller. If you have a SICK or Hokuyo LMS device, you can also make a 2D map of an environment and be able to give the robot Autonomous navigation commands from a GUI application. 
 
 > If you have any problems, get stuck, lost, confused, find errors, just want to say thanks, etc, highlight the area of the document and leave a comment. I’ll try to keep this up to date as best as I can whenever I receive feedback. :)
 
-### System Installation
-#### ROS Installation
+## System Installation
+### ROS Installation
 > Install wiki page works well: http://www.ros.org/wiki/melodic/Installation/Ubuntu
 > Select the -desktop-full package.
 
-#### Gazebo Standalone
-> __THIS FORK FIXES HAVING TO USE GAZEBO 1.6. SO FEEL FREE TO DOWNLOAD A CURRENT VERSION.__ 
-
-> _The Pioneer3AT ROS package requires some features in Gazebo-1.6 which is still under development, so we need to install from source at this time._
- `mkdir ~/gazebo`
- `cd ~/gazebo`
-  `hg clone https://bitbucket.org/osrf/gazebo gazebo`
-  `mkdir -p ~/gazebo/gazebo/build`
-  `cd ~/gazebo/gazebo/build`
-  `cmake ..`
-  `make -j 8         # Replace 8 with the number of cores in your system`
-  `sudo make install`
-
-#### Workspace Setup:
+### Workspace Setup:
 > Check the ROS website for installing and setting up the workspace
 
-#### Gazebo Dependencies
+### Gazebo Dependencies
 > Apparently, Gazebo 9 a new set of dependencies from Ignition was introduced. Follow [these instructions](http://gazebosim.org/tutorials?tut=install_dependencies_from_source) to download them.
 
-#### Userspace Installation 
-##### RosAria
+### Userspace Installation 
+#### RosAria
   > `cd ~/catkin_ws/src`<br>
   > `git clone https://github.com/amor-ros-pkg/rosaria.git`<br>
   > `cd ..`<br>
   > `rosdep install rosaria`<br>
   > `catkin_make`<br>
   > `source ~/.bashrc`<br>
-##### Pioneer 3AT
+#### Pioneer 3AT
   > `cd ~/catkin_ws/src`<br>
   > `git clone git://github.com/dawonn/ros-pioneer3at.git`<br>
   > `cd ..`<br>
   > `rosdep install pioneer3at`<br>
   > `catkin_make`<br>
-  > `source ~/.bashrc
+  > `source ~/.bashrc`
 
-##### Gazebo
+#### Gazebo
+  > __For directions that required Gazebo 1.6, see the [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit).__<br>
+  > Follow the instructions at [gazebosim.org](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install) for download and installation.<br>
   > `echo "export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> ~/.bashrc`<br>
-  > `echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc` _This line may depend on how you install it_<br>
-  > `source ~/.bashrc
+  > `echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc` This line may depend on how you install it.<br>
+  > `source ~/.bashrc`
 
-##### Gazebo Models
+#### Gazebo Models
   > `gazebo`
 
   > 1) Click the insert tab on the top left of the screen<br>
@@ -68,9 +54,9 @@ Instead of a README.md the project has a [google doc](https://docs.google.com/do
 
   > Note: This process downloads a copy of the models to ~/.gazebo/models/
 
-#### Using Gazebo Simulator
-##### Basic Configuration
-  > `gedit ~/catkin_ws/src/ros-pioneer3at/launch/hardware.launch`<br>
+### Using Gazebo Simulator
+#### Basic Configuration
+  > `gedit ~/catkin_ws/src/ros-pioneer3at/launch/hardware.launch` (gedit can be replaced with any text editor)<br>
   > 1) Comment the physical robot and lidar drivers<br>
   > 2) Uncomment the gazebo robot and lidar drivers<br>
   > Example:<br>
@@ -113,7 +99,7 @@ Instead of a README.md the project has a [google doc](https://docs.google.com/do
 
   > `<plugin name="SkidSteerDrivePlugin" filename="libSkidSteerDrivePlugin.so" />`<br>
 
-##### Launch Control Demo __(According to what I did)
+#### Launch Control Demo __(According to what I did)
   > `cd catkin_ws/src/pioneer3at/launch/core`<br>
   > `roslaunch gazebo.launch`<br>
   

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Programs that show how to drive a Pioneer3-AT robot with ros.
 
 ## README
-This README is adapted from this [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit), which has some better formatting and diagrams if the instructions here are confusing.
+This README is adapted from this [google doc](https://docs.google.com/document/d/1C_GdAAQck-IT4H5GnsH3j6OezUbehUphtlnn8XU4XBk/edit), which has some better formatting and diagrams if the instructions here are confusing.
 
 ## Introduction
 > This is a quick-start guide to using a Pioneer3AT Mobile Robot with ROS. It should allow you to drive a robot via a GUI application or a PS3 controller. If you have a SICK or Hokuyo LMS device, you can also make a 2D map of an environment and be able to give the robot Autonomous navigation commands from a GUI application. 
@@ -13,7 +13,7 @@ This README is adapted from this [google doc](https://docs.google.com/document/d
 ### ROS Installation
 > Install wiki page works well: http://www.ros.org/wiki/melodic/Installation/Ubuntu
 > Select the -desktop-full package.
-
+https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit
 ### Workspace Setup:
 > Check the ROS website for installing and setting up the workspace
 
@@ -37,7 +37,7 @@ This README is adapted from this [google doc](https://docs.google.com/document/d
   > `source ~/.bashrc`
 
 #### Gazebo
-  > __For directions that required Gazebo 1.6, see the [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit).__<br>
+_For directions that required Gazebo 1.6, see the [google doc](https://docs.google.com/document/d/1C_GdAAQck-IT4H5GnsH3j6OezUbehUphtlnn8XU4XBk/edit)._
   > Follow the instructions at [gazebosim.org](http://gazebosim.org/tutorials?tut=install_ubuntu&cat=install) for download and installation.<br>
   > `echo "export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> ~/.bashrc`<br>
   > `echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc` This line may depend on how you install it.<br>
@@ -59,7 +59,7 @@ This README is adapted from this [google doc](https://docs.google.com/document/d
   > `gedit ~/catkin_ws/src/ros-pioneer3at/launch/hardware.launch` (gedit can be replaced with any text editor)<br>
   > 1) Comment the physical robot and lidar drivers<br>
   > 2) Uncomment the gazebo robot and lidar drivers<br>
-  > Example:<br>
+  
   > `<!-- Select the robot-driver you wish to use -->`<br>
   > `<include file="$(find pioneer3at)/launch/core/gazebo.launch" />`<br>
   > `<!-- <include file="$(find pioneer3at)/launch/core/rosaria.launch" /> -->`<br>
@@ -71,7 +71,7 @@ This README is adapted from this [google doc](https://docs.google.com/document/d
   > `<!-- <include file="$(find pioneer3at)/launch/lidar/hokuyo.launch" /> -->`<br>
 
   > `gedit ~/catkin_ws/src/ros-pioneer3at/launch/ui.launch`<br>	
-  > 1) Select the control method you want to use<br>
+  > 1) Select the control method you want to use.<br>
   > `<!-- Select the control method you wish to use -->`<br>
   > `<include file="$(find pioneer3at)/launch/control/rqt_robot_steering.launch" />`<br>
   > `<!-- <include file="$(find pioneer3at)/launch/control/ps3joy.launch" /> -->`<br>
@@ -99,11 +99,26 @@ This README is adapted from this [google doc](https://docs.google.com/document/d
 
   > `<plugin name="SkidSteerDrivePlugin" filename="libSkidSteerDrivePlugin.so" />`<br>
 
-#### Launch Control Demo __(According to what I did)
-  > `cd catkin_ws/src/pioneer3at/launch/core`<br>
-  > `roslaunch gazebo.launch`<br>
+#### Launch Control Demo
+This demo is the most basic example; you can send movement messages to the robot along the `/Pioneer3AT/cmd_vel` topic.
+
+  > `cd catkin_ws/src/pioneer3at/launch/`<br>
+  > `roslaunch hardware.launch`<br>
   
   > Then, in another terminal:
   > `gzclient`
 
-  With this most basic example you can send movement messages to the robot along the `/Pioneer3AT/cmd_vel` topic.
+#### Control Demo Explanation
+File paths here are all prefixed by `~catkin_ws/src/pioneer3at`.
+
+`launch/hardware.launch` runs `launch/core/gazebo.launch`.
+
+`gazebo.launch` in turn opens a world (`config/gazebo/wg_world.sdf`) with all the models needed in a gazebo server, and runs a ROS node from `src/gazebo_bridge.cc` that connects Gazebo to ROS communication so the robot can be controlled.
+
+`hardware.launch` then enables the laser attached to the robot model with `launch/lidar/gazebo_hokuyo.launch`.
+
+`gazebo_hokuyo.launch` runs a laser-scanning ROS node from `src/gazebo_laserscan.cc` which publishes information from the laser sensor.
+
+Finally, `hardware.launch` runs `launch/core/urdf.launch` and `cmd_vel_mux.launch`. The first opens a ROS node that publishes location+orientation information about the robot, and the second _seems to remap a ROS topic so robot-control commands can be communicated along Pioneer3AT/cmd\_vel (This information should be reviewed)._
+  
+__If you want to run more complex examples, check out `demo_navigation_amcl.launch` and `demo_navigation_gmapping.launch`.__

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Instead of a README.md the project has a [google doc](https://docs.google.com/do
 
 ### System Installation
 #### ROS Installation
-> Install wiki page works well: http://www.ros.org/wiki/hydro/Installation/Ubuntu
+> Install wiki page works well: http://www.ros.org/wiki/melodic/Installation/Ubuntu
 > Select the -desktop-full package.
 
 #### Gazebo Standalone
@@ -32,6 +32,9 @@ Instead of a README.md the project has a [google doc](https://docs.google.com/do
 
 #### Workspace Setup:
 > Check the ROS website for installing and setting up the workspace
+
+#### Gazebo Dependencies
+> Apparently, Gazebo 9 a new set of dependencies from Ignition was introduced. Follow [these instructions](http://gazebosim.org/tutorials?tut=install_dependencies_from_source) to download them.
 
 #### Userspace Installation 
 ##### RosAria

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Programs that show how to drive a Pioneer3-AT robot with ros (I used it for Gazebo).
 
 ## This fork
-I donwloaded this example to learn how to use ROS (system for robot communication) and Gazebo (robot simulator) in tandem. This project contains more content than what I used, but at least for my case I noticed 2 shortcomings: there's no README in the original, and it doesn't work with the latest version of Gazebo, which in my case is version 9.
+I donwloaded this example to learn how to use ROS (system for robot communication) and Gazebo (robot simulator) in tandem. This project contains more content than what I used, but at least for my case I noticed 2 shortcomings: there's no README in the original, and it doesn't work with the latest version of Gazebo, which in my case is version 9. To the former I've contributed by starting this file, and for the latter I changed a couple of source files a smidge. 
 
 ## README
 Instead of a README.md the project has a [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit), which I'll try to paste below.
@@ -119,6 +119,5 @@ Instead of a README.md the project has a [google doc](https://docs.google.com/do
 
   With this most basic example you can send movement messages to the robot along the `/Pioneer3AT/cmd_vel` topic.
 
-## Updating basic usage with Gazebo for version 9
-### Link ROS packages
-### Switch to Ignition libraries
+
+-- @ogallagher

--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ File paths here are all prefixed by `~catkin_ws/src/pioneer3at`.
 
 `gazebo_hokuyo.launch` runs a laser-scanning ROS node from `src/gazebo_laserscan.cc` which publishes information from the laser sensor.
 
-Finally, `hardware.launch` runs `launch/core/urdf.launch` and `cmd_vel_mux.launch`. The first opens a ROS node that publishes location+orientation information about the robot, and the second _seems to remap a ROS topic so robot-control commands can be communicated along Pioneer3AT/cmd\_vel (This information should be reviewed)._
+Finally, `hardware.launch` runs `launch/core/urdf.launch` and `cmd_vel_mux.launch`. The first opens a ROS node that publishes location+orientation information about the robot, and the second seems to remap a ROS topic so robot-control commands can be communicated along Pioneer3AT/cmd\_vel. _(This information should be reviewed)._
   
 __If you want to run more complex examples, check out `demo_navigation_amcl.launch` and `demo_navigation_gmapping.launch`.__

--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# ros-pioneer3at
+Programs that show how to drive a Pioneer3-AT robot with ros (I used it for Gazebo).
+
+## This fork
+I donwloaded this example to learn how to use ROS (system for robot communication) and Gazebo (robot simulator) in tandem. This project contains more content than what I used, but at least for my case I noticed 2 shortcomings: there's no README in the original, and it doesn't work with the latest version of Gazebo, which in my case is version 9.
+
+## README
+Instead of a README.md the project has a [google doc](https://docs.google.com/document/d/1-HmQuTe955WDy5t9Q70rw00o4WJjFePuAhqxbgarA1Q/edit), which I'll try to paste below.
+
+### Introduction
+> This is a quick-start guide to using a Pioneer3AT Mobile Robot with ROS. It should allow you to drive a robot via a GUI application or a PS3 controller. If you have a SICK or Hokuyo LMS device, you can also make a 2D map of an environment and be able to give the robot Autonomous navigation commands from a GUI application. 
+
+> If you have any problems, get stuck, lost, confused, find errors, just want to say thanks, etc, highlight the area of the document and leave a comment. I’ll try to keep this up to date as best as I can whenever I receive feedback. :)
+
+### System Installation
+#### ROS Installation
+> Install wiki page works well: http://www.ros.org/wiki/hydro/Installation/Ubuntu
+> Select the -desktop-full package.
+
+#### Gazebo Standalone
+> __THIS FORK FIXES HAVING TO USE GAZEBO 1.6. SO FEEL FREE TO DOWNLOAD A CURRENT VERSION.__ 
+
+> _The Pioneer3AT ROS package requires some features in Gazebo-1.6 which is still under development, so we need to install from source at this time._
+ `mkdir ~/gazebo`
+ `cd ~/gazebo`
+  `hg clone https://bitbucket.org/osrf/gazebo gazebo`
+  `mkdir -p ~/gazebo/gazebo/build`
+  `cd ~/gazebo/gazebo/build`
+  `cmake ..`
+  `make -j 8         # Replace 8 with the number of cores in your system`
+  `sudo make install`
+
+#### Workspace Setup:
+> Check the ROS website for installing and setting up the workspace
+
+#### Userspace Installation 
+##### RosAria
+  > `cd ~/catkin_ws/src`<br>
+  > `git clone https://github.com/amor-ros-pkg/rosaria.git`<br>
+  > `cd ..`<br>
+  > `rosdep install rosaria`<br>
+  > `catkin_make`<br>
+  > `source ~/.bashrc`<br>
+##### Pioneer 3AT
+  > `cd ~/catkin_ws/src`<br>
+  > `git clone git://github.com/dawonn/ros-pioneer3at.git`<br>
+  > `cd ..`<br>
+  > `rosdep install pioneer3at`<br>
+  > `catkin_make`<br>
+  > `source ~/.bashrc
+
+##### Gazebo
+  > `echo "export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> ~/.bashrc`<br>
+  > `echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc` _This line may depend on how you install it_<br>
+  > `source ~/.bashrc
+
+##### Gazebo Models
+  > `gazebo`
+
+  > 1) Click the insert tab on the top left of the screen<br>
+  > 2) Expand the ‘Model Database’<br>
+  > 3) Insert a Pioneer 3AT model into the world<br>
+  > 4) Insert a Willow Garage model into the world<br>
+  > 5) Close Gazebo
+
+  > Note: This process downloads a copy of the models to ~/.gazebo/models/
+
+#### Using Gazebo Simulator
+##### Basic Configuration
+  > `gedit ~/catkin_ws/src/ros-pioneer3at/launch/hardware.launch`<br>
+  > 1) Comment the physical robot and lidar drivers<br>
+  > 2) Uncomment the gazebo robot and lidar drivers<br>
+  > Example:<br>
+  > `<!-- Select the robot-driver you wish to use -->`<br>
+  > `<include file="$(find pioneer3at)/launch/core/gazebo.launch" />`<br>
+  > `<!-- <include file="$(find pioneer3at)/launch/core/rosaria.launch" /> -->`<br>
+  > `<!-- <include file="$(find pioneer3at)/launch/core/p2os_driver.launch" /> -->`<br>
+
+  > `<!-- Select the laser you wish to use -->`<br>
+  > `<include file="$(find pioneer3at)/launch/lidar/gazebo_hokuyo.launch" />`<br>
+  > `<!-- <include file="$(find pioneer3at)/launch/lidar/sicklms.launch" /> -->`<br>
+  > `<!-- <include file="$(find pioneer3at)/launch/lidar/hokuyo.launch" /> -->`<br>
+
+  > `gedit ~/catkin_ws/src/ros-pioneer3at/launch/ui.launch`<br>	
+  > 1) Select the control method you want to use<br>
+  > `<!-- Select the control method you wish to use -->`<br>
+  > `<include file="$(find pioneer3at)/launch/control/rqt_robot_steering.launch" />`<br>
+  > `<!-- <include file="$(find pioneer3at)/launch/control/ps3joy.launch" /> -->`<br>
+  > `<!-- <include file="$(find pioneer3at)/launch/control/xboxjoy.launch" /> -->`<br>
+
+  > `sudo gedit ~/.gazebo/models/pioneer3at/model.sdf`<br>
+  > 1) Uncomment the hokuyo and skidsteerdrive plugin near the bottom<br>
+  > 2) Remove the <MaxForce> tag<br>
+  > Example:<br>
+  > `<include>`<br>
+  > `  <uri>model://hokuyo</uri>`<br>
+  > `  <pose>0.2 0 0.13 0 0 0</pose>`<br>
+  > `</include>`<br>
+  > `<joint name="hokuyo_joint" type="revolute">`<br>
+  > `  <child>hokuyo::link</child>`<br>
+  > `  <parent>chassis</parent>`<br>
+  > `  <axis>`<br>
+  > `    <xyz>0 0 1</xyz>`<br>
+  > `    <limit>`<br>
+  > `      <upper>0</upper>`<br>
+  > `      <lower>0</lower>`<br>
+  > `    </limit>`<br>
+  > `  </axis>`<br>
+  > `</joint>`
+
+  > `<plugin name="SkidSteerDrivePlugin" filename="libSkidSteerDrivePlugin.so" />`<br>
+
+##### Launch Control Demo __(According to what I did)
+  > `cd catkin_ws/src/pioneer3at/launch/core`<br>
+  > `roslaunch gazebo.launch`<br>
+  
+  > Then, in another terminal:
+  > `gzclient`
+
+  With this most basic example you can send movement messages to the robot along the `/Pioneer3AT/cmd_vel` topic.
+
+## Updating basic usage with Gazebo for version 9
+### Link ROS packages
+### Switch to Ignition libraries

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ _For directions that required Gazebo 1.6, see the [google doc](https://docs.goog
   > `<!-- <include file="$(find pioneer3at)/launch/control/xboxjoy.launch" /> -->`<br>
 
   > `sudo gedit ~/.gazebo/models/pioneer3at/model.sdf`<br>
-  > 1) Uncomment the hokuyo and skidsteerdrive plugin near the bottom<br>
+  > 1) Uncomment the skidsteerdrive plugin near the bottom:<br>
   > 2) Remove the <MaxForce> tag<br>
-  > Example:<br>
+  > 3) Add the following:<br>
   > `<include>`<br>
   > `  <uri>model://hokuyo</uri>`<br>
   > `  <pose>0.2 0 0.13 0 0 0</pose>`<br>
@@ -96,8 +96,6 @@ _For directions that required Gazebo 1.6, see the [google doc](https://docs.goog
   > `    </limit>`<br>
   > `  </axis>`<br>
   > `</joint>`
-
-  > `<plugin name="SkidSteerDrivePlugin" filename="libSkidSteerDrivePlugin.so" />`<br>
 
 #### Launch Control Demo
 This demo is the most basic example; you can send movement messages to the robot along the `/Pioneer3AT/cmd_vel` topic.

--- a/src/gazebo_bridge.cc
+++ b/src/gazebo_bridge.cc
@@ -23,7 +23,8 @@
 
 #include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/msgs.hh>
-#include <gazebo/math/gzmath.hh>
+//#include <gazebo/math/gzmath.hh> //This library was replaced with ignition::math
+#include <ignition/math.hh>
 
 #include <iostream>
 
@@ -42,16 +43,22 @@ double ros_odom_tf_future_date;
 void ros_cmd_vel_Callback(const geometry_msgs::Twist::ConstPtr& msg_in)
 { 
   // Generate a pose
-  gazebo::math::Pose pose(msg_in->linear.x,
-                          msg_in->linear.y,
-                          msg_in->linear.z,
-                          msg_in->angular.x,
-                          msg_in->angular.y,
-                          msg_in->angular.z);
+//   gazebo::math::Pose pose(msg_in->linear.x,
+//                           msg_in->linear.y,
+//                           msg_in->linear.z,
+//                           msg_in->angular.x,
+//                           msg_in->angular.y,
+//                           msg_in->angular.z);
+  ignition::math::Pose3<double> pose(msg_in->linear.x,
+                                     msg_in->linear.y,
+                                     msg_in->linear.z,
+                                     msg_in->angular.x,
+                                     msg_in->angular.y,
+                                     msg_in->angular.z);
   
   // Convert to a pose message
-  gazebo::msgs::Pose msg_out;
-  gazebo::msgs::Set(&msg_out, pose);
+  gazebo::msgs::Pose msg_out = gazebo::msgs::Convert(pose);
+//   gazebo::msgs::Set(&msg_out, pose);
   gz_vel_cmd_pub->Publish(msg_out);
 }
 


### PR DESCRIPTION
I was able to run the most basic ROS control example with Gazebo 9 after installing some new dependencies and modifying a couple of source files. I described the changes in the README.